### PR TITLE
fix: extend RefCounted in GodotObjectAdapter

### DIFF
--- a/Chickensoft.GodotNodeInterfaces/src/added_functionality/Adapters.cs
+++ b/Chickensoft.GodotNodeInterfaces/src/added_functionality/Adapters.cs
@@ -9,7 +9,7 @@ public interface IGodotObjectAdapter : IGodotObject {
 }
 
 /// <summary>A Godot node API adapter.</summary>
-public partial  interface INodeAdapter : IGodotObjectAdapter, INode {
+public partial interface INodeAdapter : IGodotObjectAdapter, INode {
   /// <summary>Underlying Godot node this adapter uses.</summary>
   public new Node TargetObj { get; }
 }

--- a/Chickensoft.GodotNodeInterfacesGenerator/src/Main.cs
+++ b/Chickensoft.GodotNodeInterfacesGenerator/src/Main.cs
@@ -327,7 +327,7 @@ public static class GodotNodeInterfacesGenerator {
 
       var adapterParent = extendsAnotherObj
         ? $"{baseType.Name}Adapter, "
-        : "GodotObject, ";
+        : "RefCounted, ";
 
       var adapterBaseCall = extendsAnotherObj
         ? " : base(@object) "


### PR DESCRIPTION
Extending from `GodotObject` will leak instances because Godot cannot manage the references automatically