### PR TITLE
chore: bump .NET, Godot versions

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -5,6 +5,7 @@
       "label": "build_and_generate",
       "command": "dotnet",
       "type": "process",
+      "group": "build",
       "args": [
         "build",
         "--no-restore"
@@ -26,6 +27,7 @@
       "label": "build",
       "command": "dotnet",
       "type": "process",
+      "group": "build",
       "args": [
         "build",
         "--no-restore"

--- a/Chickensoft.GodotNodeInterfaces.Tests/Chickensoft.GodotNodeInterfaces.Tests.csproj
+++ b/Chickensoft.GodotNodeInterfaces.Tests/Chickensoft.GodotNodeInterfaces.Tests.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Godot.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <EnableDynamicLoading>true</EnableDynamicLoading>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
     <RootNamespace>Chickensoft.GodotNodeInterfaces.Tests</RootNamespace>
     <!-- Required for some nuget packages to work -->

--- a/Chickensoft.GodotNodeInterfaces/Chickensoft.GodotNodeInterfaces.csproj
+++ b/Chickensoft.GodotNodeInterfaces/Chickensoft.GodotNodeInterfaces.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <EnableDynamicLoading>true</EnableDynamicLoading>
     <LangVersion>preview</LangVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -40,7 +40,7 @@
 
   <ItemGroup>
     <!-- Dependencies go here. -->
-    <PackageReference Include="GodotSharp" Version="4.3.0" />
+    <PackageReference Include="GodotSharp" Version="4.4.1" />
 
     <!-- Required for inheritdoc -->
     <PackageReference Include="SauceControl.InheritDoc" Version="2.0.2">

--- a/Chickensoft.GodotNodeInterfacesGenerator/Chickensoft.GodotNodeInterfacesGenerator.csproj
+++ b/Chickensoft.GodotNodeInterfacesGenerator/Chickensoft.GodotNodeInterfacesGenerator.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <EnableDynamicLoading>true</EnableDynamicLoading>
     <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <!-- Dependencies go here. -->
-    <PackageReference Include="GodotSharp" Version="4.3.0" />
+    <PackageReference Include="GodotSharp" Version="4.4.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" PrivateAssets="all" />
     <!-- Lets us get XML documentation easily. -->

--- a/global.json
+++ b/global.json
@@ -4,6 +4,6 @@
     "rollForward": "latestMinor"
   },
   "msbuild-sdks": {
-    "Godot.NET.Sdk": "4.3.0"
+    "Godot.NET.Sdk": "4.4.1"
   }
 }


### PR DESCRIPTION
Fixes issues with test workflow runs on Ubuntu.

* Bumped .NET target framework to .NET 8 for all projects
* Bumped Godot target version to 4.4.1
* Added both build tasks to the "build" group in VSCode for ease of use