### PR TITLE
doc: update badge URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ If you use these methods instead of the Godot version, you can mock subtree oper
 Just install the package from nuget!
 
 ```sh
-dotnet add package Chickensoft.GodotNodeInterfaces 
+dotnet add package Chickensoft.GodotNodeInterfaces
 ```
 
 ## 📖 Usage
@@ -225,11 +225,11 @@ If your project is setup to require approvals before pull requests can be merged
 
 🐣 Package generated from a 🐤 Chickensoft Template — <https://chickensoft.games>
 
-[chickensoft-badge]: https://raw.githubusercontent.com/chickensoft-games/chickensoft_site/main/static/img/badges/chickensoft_badge.svg
+[chickensoft-badge]: https://chickensoft.games/img/badges/chickensoft_badge.svg
 [chickensoft-website]: https://chickensoft.games
-[discord-badge]: https://raw.githubusercontent.com/chickensoft-games/chickensoft_site/main/static/img/badges/discord_badge.svg
+[discord-badge]: https://chickensoft.games/img/badges/discord_badge.svg
 [discord]: https://discord.gg/gSjaPgMmYW
-[read-the-docs-badge]: https://raw.githubusercontent.com/chickensoft-games/chickensoft_site/main/static/img/badges/read_the_docs_badge.svg
+[read-the-docs-badge]: https://chickensoft.games/img/badges/read_the_docs_badge.svg
 [docs]: https://chickensoft.games/docsickensoft%20Discord-%237289DA.svg?style=flat&logo=discord&logoColor=white
 
 [setup-docs]: https://chickensoft.games/docs/setup


### PR DESCRIPTION
Updated badge URLs in README to match the new Chickensoft site.