### PR TITLE
chore: remove outdated comment in workflow

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         # Put the operating systems you want to run on here.
-        os: [ubuntu-latest] # , macos-latest, windows-2019
+        os: [ubuntu-latest]
     env:
       DOTNET_CLI_TELEMETRY_OPTOUT: true
       DOTNET_NOLOGO: true


### PR DESCRIPTION
Removed a comment in test workflow referencing the windows-2019 action runner, which is being deprecated and isn't used here.